### PR TITLE
fix: fixing a ReferenceError on movies variable

### DIFF
--- a/src/movies.js
+++ b/src/movies.js
@@ -1,7 +1,3 @@
-// The `movies` array from the file `src/data.js`.
-console.log('movies: ', movies);
-
-
 // Iteration 1: All directors? - Get the array of all directors.
 // _Bonus_: It seems some of the directors had directed multiple movies so they will pop up multiple times in the array of directors.
 // How could you "clean" a bit this array and make it unified (without duplicates)?


### PR DESCRIPTION
`movies` will be passed as 1st parameter of the different functions by the tests, but the variable does not exist here